### PR TITLE
Change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "egghead-ui",
+  "name": "egghead-io-styleguide",
   "version": "0.1.0",
   "homepage": "https://ui.egghead.io",
   "main": "build/index.js",


### PR DESCRIPTION
* Change package name from `egghead-ui` to `egghead-io-styleguide` so I can migrate components to `egghead-ui`

![image](https://cloud.githubusercontent.com/assets/2262858/22346869/ee999fd0-e3c2-11e6-86d7-00516de1d9ee.png)
